### PR TITLE
Simplify tox environment passing in workflows

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -36,11 +36,8 @@ jobs:
           # development (git) versions of all Qiskit packages.
           sed -i 's|^\(qiskit[A-Za-z-]*\).*|git+https://github.com/Qiskit/\1.git|' requirements-dev.txt requirements.txt
           pip install tox
-      - name: Specify tox environment
+      - name: Test using tox environment
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
-      - name: Test using tox
-        run: |
-          tox
+          tox -epy${pver/./}

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -25,13 +25,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up tox environment
+      - name: Specify tox environment
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox_env="-epy${pver/./}"
-          echo tox_env
-          echo TOX_ENV=$tox_env >> $GITHUB_ENV
+          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -43,6 +41,6 @@ jobs:
           # development (git) versions of all Qiskit packages.
           sed -i 's|^\(qiskit[A-Za-z-]*\).*|git+https://github.com/Qiskit/\1.git|' requirements-dev.txt requirements.txt
           pip install tox
-      - name: Test using tox environment
+      - name: Test using tox
         run: |
-          tox ${{ env.TOX_ENV }}
+          tox

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -25,11 +25,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Specify tox environment
-        shell: bash
-        run: |
-          pver=${{ matrix.python-version }}
-          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -41,6 +36,11 @@ jobs:
           # development (git) versions of all Qiskit packages.
           sed -i 's|^\(qiskit[A-Za-z-]*\).*|git+https://github.com/Qiskit/\1.git|' requirements-dev.txt requirements.txt
           pip install tox
+      - name: Specify tox environment
+        shell: bash
+        run: |
+          pver=${{ matrix.python-version }}
+          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
       - name: Test using tox
         run: |
           tox

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -35,11 +35,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Specify tox environment
+      - name: Test using tox environment
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
-      - name: Test using tox
-        run: |
-          tox
+          tox -epy${pver/./}

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -31,15 +31,15 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
       - name: Specify tox environment
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
           echo TOXENV="py${pver/./}" >> $GITHUB_ENV
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
       - name: Test using tox
         run: |
           tox

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -31,17 +31,15 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up tox environment
+      - name: Specify tox environment
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox_env="-epy${pver/./}"
-          echo tox_env
-          echo TOX_ENV=$tox_env >> $GITHUB_ENV
+          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Test using tox environment
+      - name: Test using tox
         run: |
-          tox ${{ env.TOX_ENV }}
+          tox

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -23,13 +23,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up tox environment
+      - name: Specify tox environment
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox_env="-epy${pver/./}"
-          echo tox_env
-          echo TOX_ENV=$tox_env >> $GITHUB_ENV
+          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -41,6 +39,6 @@ jobs:
           print(config["tox"]["minversion"])
           EOF
           pip install tox==$(python3 get_tox_minversion.py)
-      - name: Test using tox environment
+      - name: Test using tox
         run: |
-          tox ${{ env.TOX_ENV }}
+          tox

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -23,11 +23,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Specify tox environment
-        shell: bash
-        run: |
-          pver=${{ matrix.python-version }}
-          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -39,6 +34,11 @@ jobs:
           print(config["tox"]["minversion"])
           EOF
           pip install tox==$(python3 get_tox_minversion.py)
+      - name: Specify tox environment
+        shell: bash
+        run: |
+          pver=${{ matrix.python-version }}
+          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
       - name: Test using tox
         run: |
           tox

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -34,11 +34,8 @@ jobs:
           print(config["tox"]["minversion"])
           EOF
           pip install tox==$(python3 get_tox_minversion.py)
-      - name: Specify tox environment
+      - name: Test using tox environment
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          echo TOXENV="py${pver/./}" >> $GITHUB_ENV
-      - name: Test using tox
-        run: |
-          tox
+          tox -epy${pver/./}


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

~~I found out that tox looks directly at `TOXENV`, allowing for some simplification.~~

Actually, scratch that.  While the above statement is true, I found a way to be even more concise and explicit without relying on `TOXENV`.

### Details and comments

