### PR TITLE
Upload coverage report to Coveralls in Actions workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install tox coveragepy-lcov
       - name: Run coverage
         run: tox -ecoverage
+      - name: Convert to lcov
+        run: coveragepy-lcov --output_file_path coveralls.info
+      - name: Upload report to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coveralls.info

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License](https://img.shields.io/github/license/IBM-Quantum-prototypes/quantum-prototype-template?label=License)](https://github.com/IBM-Quantum-prototypes/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
 [![Tests](https://github.com/IBM-Quantum-prototypes/quantum-prototype-template/actions/workflows/test_latest_versions.yml/badge.svg)](https://github.com/IBM-Quantum-prototypes/quantum-prototype-template/actions/workflows/test_latest_versions.yml)
+[![Coverage](https://coveralls.io/repos/github/qiskit-community/quantum-prototype-template/badge.svg?branch=main)](https://coveralls.io/github/qiskit-community/quantum-prototype-template?branch=main)
 
 # Quantum Prototype Template
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This uploads the coverage reports to coveralls, which is used by some Qiskit packages.

### Details and comments

I'll add the coveralls badge in a future commit, once this is working.