### PR TITLE
Modify `tox.ini` to work with tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 minversion = 2.1
 envlist = py37, py38, py39, py310, lint, coverage
 # CI: skip-next-line
-skipsdist = true
-# CI: skip-next-line
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With tox4, `importlib_metadata` complains when `skipsdist = true`, so let's disable it.

See similar commit at
https://github.com/qiskit-community/prototype-qrao/commit/8ea32c0182dd5e37b2a66d6890dfc42cfe82295d

### Details and comments

