### PR TITLE
Bump Python versions used for dev version tests

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, '3.10']
+        python-version: [3.8, 3.11]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Qiskit Terra `main` now requires Python 3.8 or higher.

### Details and comments

